### PR TITLE
get path_to_wd automagically

### DIFF
--- a/analysis/main.Rmd
+++ b/analysis/main.Rmd
@@ -85,11 +85,8 @@ detach_all_packages()
 # this allows multiple persons to use the same RMarkdown
 # without adjusting the working directory by themselves all the time
 # set your working directory here
-path_to_wd <- switch(EXPR = system2("whoami", stdout = TRUE),
-                     "person1" = "~/my-company/my-projects/rddj-template/analysis/",
-                     "person2" = "~/projects/rddj-template/analysis/",
-                     "tgrossen" = "~/Projekte/rddj-template/analysis/",
-                     "~")
+source("scripts/csf.R")
+path_to_wd <- csf()
 # nolint end
 if ( is.null(path_to_wd) ) {
   print("WARNING: No working directory specified for current user")
@@ -207,4 +204,3 @@ lintr::lint("main.Rmd")
 # if you have additional scripts and want them to be linted too, add them here
 lintr::lint("scripts/my_script.R")
 ```
-

--- a/analysis/scripts/csf.R
+++ b/analysis/scripts/csf.R
@@ -1,0 +1,38 @@
+# current source folder
+# improved version of
+# https://stackoverflow.com/a/36777602
+# returns getwd() if no path
+csf <- function() {
+  # http://stackoverflow.com/a/32016824/2292993
+  cmdArgs = commandArgs(trailingOnly = FALSE)
+  needle = "--file="
+  match = grep(needle, cmdArgs)
+  if (length(match) > 0) {
+    # Rscript via command line
+    return(dirname(normalizePath(sub(needle, "", cmdArgs[match]))))
+  } else {
+    ls_vars = ls(sys.frames()[[1]])
+    if ("fileName" %in% ls_vars) {
+      # Source'd via RStudio
+      return(dirname(normalizePath(sys.frames()[[1]]$fileName)))
+    } else {
+      if (!is.null(sys.frames()[[1]]$ofile)) {
+        # Source'd via R console
+        return(dirname(normalizePath(sys.frames()[[1]]$ofile)))
+      } else {
+        # RStudio Run Selection
+        # http://stackoverflow.com/a/35842176/2292993
+        if (requireNamespace("knitr") && !is.null(knitr::current_input())) {
+          # this fork is inspired by https://github.com/krlmlr/kimisc/blob/master/R/thisfile.R
+          return (dirname(knitr::current_input()))
+        } else {
+          if(nchar(rstudioapi::getActiveDocumentContext()$path)>0) {
+            return(dirname(normalizePath(rstudioapi::getActiveDocumentContext()$path)))
+          } else { #console
+            return(getwd());
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
this should get rid of the path_to_wd switch.

i couldn't test this cross-platform, but it works in rstudio (run all chunks, run single chunk, knitr) and using your new deployscript outside of Rstudio, all on OSX